### PR TITLE
Add support for cluster id 

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ Predefine following parameters inside your vars files. Working examples can be f
 | ttl | Time to Live (in seconds) | Int | False | N/A | 600 | 600 |
 | ttl_state | Trigger state at the expiration of 'ttl' | String | False | NODATA <br> DEL <br> ERROR <br> WARN <br> OK | NODATA | WARN |
 | is_remote | Use remote storage | Bool | False | True <br> False | False | False |
+| trigger_source | Specify trigger source, overrides is_remote | String | False | graphite_local <br>  graphite_remote <br> prometheus_remote | None | graphite_local
+| cluster_id | Specify cluster id | String | False | N/A | None | default
 | desc | Trigger description | String | False | N/A | Empty string | trigger test description |
 | mute_new_metrics | Mute new metrics | Bool | False | True <br> False | False | False |
 | disabled_days | Days for trigger to be in silent mode | List | False | N/A | Empty list | - Mon <br> - Wed |

--- a/library/moira_trigger.py
+++ b/library/moira_trigger.py
@@ -131,6 +131,10 @@ options:
       - Specify trigger source, overrides is_remote
     required: False
     choices: ['graphite_local', 'graphite_remote', 'prometheus_remote']
+  cluster_id:
+    description:
+      - Specify cluster id
+    required: False
   desc:
     description:
       - Trigger description.
@@ -523,6 +527,10 @@ def main():
             'type': 'str',
             'required': False,
             'choices': ['graphite_local', 'graphite_remote', 'prometheus_remote']},
+        'cluster_id': {
+            'type': 'str',
+            'required': False,
+            'default': None},
         'desc': {
             'type': 'str',
             'required': False,

--- a/library/moira_trigger.py
+++ b/library/moira_trigger.py
@@ -133,7 +133,7 @@ options:
     choices: ['graphite_local', 'graphite_remote', 'prometheus_remote']
   cluster_id:
     description:
-      - Specify cluster id
+      - Specify cluster id. List of available clusters can be seen in api at `https://your-moira-url/api/config`
     required: False
   desc:
     description:
@@ -589,6 +589,7 @@ def main():
         'tags': module.params['tags'],
         'mute_new_metrics': module.params['mute_new_metrics'],
         'trigger_source': module.params['trigger_source'],
+        'cluster_id': module.params['cluster_id'],
         'sched': get_schedule(
             module.params['start_hour'],
             module.params['start_minute'],

--- a/tasks/manage_triggers.yml
+++ b/tasks/manage_triggers.yml
@@ -20,6 +20,7 @@
     ttl_state: '{{ item.ttl_state | default(omit) }}' # Trigger state at the expiration of 'ttl' (string)
     is_remote: '{{ item.is_remote | default(omit) }}' # Use remote storage (bool)
     trigger_source: '{{ item.trigger_source | default(omit) }}' # Specify trigger source, override is_remote (str)
+    cluster_id: '{{ item.cluster_id | default(omit) }}' # Specify cluster_id (str)
     desc: '{{ item.desc | default(omit) }}' # Trigger description (string)
     mute_new_metrics: '{{ item.mute_new_metrics | default(omit) }}' # Mute new metrics (bool)
     disabled_days: '{{ item.disabled_days | default(omit) }}' # Days for trigger to be in silent mode (list)


### PR DESCRIPTION
Add field `cluster_id` for triggers to support multiple clusters

List of available clusters can be seen in api at `https://your-moira-url/api/config`